### PR TITLE
update crdify to ack break change.

### DIFF
--- a/.github/workflows/crd-validation.yml
+++ b/.github/workflows/crd-validation.yml
@@ -2,10 +2,11 @@ name: CRD Validation
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   crd-validation:
@@ -28,7 +29,17 @@ jobs:
         run: |
           go install sigs.k8s.io/crdify@latest
 
+      - name: Reset Validation Approval
+        if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, '/ack-breaking-changes')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "/ack-breaking-changes"
+          echo "⚠️ Removed '/ack-breaking-changes' label due to new changes. Re-approval required."
+
       - name: Run CRD Validation Check
+        env:
+          ALLOW_BREAKING: ${{ contains(github.event.pull_request.labels.*.name, '/ack-breaking-changes') && github.event.action != 'synchronize' }}
         run: |
           git fetch origin ${{ github.base_ref }}:upstream_base
           BASE_SHA=$(git rev-parse upstream_base)
@@ -44,8 +55,14 @@ jobs:
           done
 
           if [ "$FAILED" -gt 0 ]; then
-            echo "::error::Validation failed! Found $FAILED incompatible CRD change(s)."
-            exit 1
+            if [[ "$ALLOW_BREAKING" == "true" ]]; then
+               echo "⚠️ Validation failed with $FAILED incompatible change(s), but allowed via '/ack-breaking-changes' label."
+               exit 0
+            else
+               echo "❌ error: Validation failed! Found $FAILED incompatible CRD change(s)."
+               echo "⚠️ notice: To allow these changes, a reviewer must add the '/ack-breaking-changes' label to the PR."
+               exit 1
+            fi
           fi
 
           echo "All CRDs are compatible."


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Gateway API Inference Extension, please read our
   developer guide (https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/docs/dev.md)
   and our community page (https://gateway-api-inference-extension.sigs.k8s.io/contributing/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. If this PR is a new design proposal, please review existing design docs for guidance:
   https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/docs/proposals
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind gep
/kind test

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/area conformance-test
/area conformance-machinery
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note

```
