### PR TITLE
Add load balancing factor to EPP scoring

### DIFF
--- a/pkg/epp/scheduling/scheduler_profile.go
+++ b/pkg/epp/scheduling/scheduler_profile.go
@@ -170,6 +170,29 @@ func (p *SchedulerProfile) runScorerPlugins(ctx context.Context, request *fwksch
 	}
 	logger.V(logutil.VERBOSE).Info("Completed running scorer plugins successfully")
 
+	// Calculate total active requests to compute the load balancing factor
+	totalActiveRequests := 0
+	for _, endpoint := range endpoints {
+		metrics := endpoint.GetMetrics()
+		if metrics != nil {
+			totalActiveRequests += metrics.RunningRequestsSize
+		}
+	}
+
+	// Apply balancing factor if there are any active requests
+	if totalActiveRequests > 0 {
+		for endpoint, totalScore := range weightedScorePerEndpoint {
+			activeRequests := 0
+			metrics := endpoint.GetMetrics()
+			if metrics != nil {
+				activeRequests = metrics.RunningRequestsSize
+			}
+			balancingFactor := 1.0 - (float64(activeRequests) / float64(totalActiveRequests))
+			weightedScorePerEndpoint[endpoint] = totalScore * balancingFactor
+			logger.V(logutil.DEBUG).Info("Applied load balancing factor", "endpoint", endpoint.GetMetadata().NamespacedName, "balancingFactor", balancingFactor, "newScore", weightedScorePerEndpoint[endpoint])
+		}
+	}
+
 	return weightedScorePerEndpoint
 }
 

--- a/pkg/epp/scheduling/scheduler_profile_test.go
+++ b/pkg/epp/scheduling/scheduler_profile_test.go
@@ -48,6 +48,15 @@ func TestSchedulePlugins(t *testing.T) {
 		TypeRes: "picker",
 		PickRes: k8stypes.NamespacedName{Name: "pod1"},
 	}
+	tp3 := &testPlugin{
+		TypeRes:   "test3",
+		ScoreRes:  1.0,
+		FilterRes: []k8stypes.NamespacedName{{Name: "pod1"}, {Name: "pod2"}, {Name: "pod3"}},
+	}
+	pickerPluginLoadBalancing := &testPlugin{
+		TypeRes: "picker_lb",
+		PickRes: k8stypes.NamespacedName{Name: "pod3"},
+	}
 
 	tests := []struct {
 		name                string
@@ -105,6 +114,22 @@ func TestSchedulePlugins(t *testing.T) {
 			numEndpointsToScore: 0,
 			err:                 true, // no available endpoints to server after filter all
 		},
+		{
+			name: "all plugins executed successfully, load balancing factor applied",
+			profile: NewSchedulerProfile().
+				WithFilters(tp3).
+				WithScorers(NewWeightedScorer(tp3, 1)).
+				WithPicker(pickerPluginLoadBalancing),
+			input: []fwksched.Endpoint{
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod1"}}, &fwkdl.Metrics{RunningRequestsSize: 50}, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}}, &fwkdl.Metrics{RunningRequestsSize: 40}, nil),
+				fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: k8stypes.NamespacedName{Name: "pod3"}}, &fwkdl.Metrics{RunningRequestsSize: 10}, nil),
+			},
+			wantTargetEndpoint:  k8stypes.NamespacedName{Name: "pod3"},
+			targetEndpointScore: 0.9, // base score 1.0 * factor (1 - 10/100) = 0.9
+			numEndpointsToScore: 3,
+			err:                 false,
+		},
 	}
 
 	for _, test := range tests {
@@ -136,9 +161,20 @@ func TestSchedulePlugins(t *testing.T) {
 			}
 
 			// Validate output
+			var wantTargetEndpoint fwksched.Endpoint
+			for _, ep := range test.input {
+				if ep.GetMetadata().NamespacedName == test.wantTargetEndpoint {
+					wantTargetEndpoint = ep
+					break
+				}
+			}
+			if wantTargetEndpoint == nil {
+				wantTargetEndpoint = fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: test.wantTargetEndpoint}, nil, nil)
+			}
+
 			wantRes := &fwksched.ProfileRunResult{
 				TargetEndpoints: []fwksched.Endpoint{
-					fwksched.NewEndpoint(&fwkdl.EndpointMetadata{NamespacedName: test.wantTargetEndpoint}, nil, nil),
+					wantTargetEndpoint,
 				},
 			}
 


### PR DESCRIPTION
Adding a load balancing factor to the EPP scoring will prevent hot spotting. Hotspotting can occur where some scorers persistently rank a particular endpoint with high score which potentially shifts a disproportionate amount of traffic to one or a few endpoints and leave the traffic highly skewed.

The balancing factor is defined as `1 - Active Request for the Pod / Total Active Requests`.
Modified Score = Balancing Factor * Total Score.

---
*PR created automatically by Jules for task [7272875113107199359](https://jules.google.com/task/7272875113107199359) started by @zetxqx*